### PR TITLE
fix to avoid sessions being created in an expired state

### DIFF
--- a/spray-oauth-client/src/main/scala/com/stratio/spray/oauth2/client/SessionStore.scala
+++ b/spray-oauth-client/src/main/scala/com/stratio/spray/oauth2/client/SessionStore.scala
@@ -26,7 +26,7 @@ object SessionStore {
 
   def addSession(sessionId: String, identity: String, expires: Long) = {
     synchronized {
-      sessionStore += sessionId -> (identity, expires)
+      sessionStore += sessionId -> (identity, now + expires)
     }
   }
 

--- a/spray-oauth-client/src/test/scala/com/stratio/spray/oauth2/client/SessionStoreTest.scala
+++ b/spray-oauth-client/src/test/scala/com/stratio/spray/oauth2/client/SessionStoreTest.scala
@@ -26,15 +26,15 @@ class SessionStoreTest extends FlatSpec with Matchers {
   import SessionStore._
 
   val now = System.currentTimeMillis()
-  val alive = now + 10000
-  val dead = now - 10000
+  val alive = 10000
+  val dead = -10000
   "Session Store" should "add a session" in {
 
     addSession("1", "my session content", alive)
     addSession("2", "my session content2", dead)
     addSession("3", "my session content3", dead)
 
-    sessionStore.get("1") should be(Some("my session content", alive))
+    sessionStore.get("1").map(_._1) should be(Some("my session content"))
   }
   it should "not retrieve a expired session" in {
     getSession("2") should be(None)


### PR DESCRIPTION
Sessions were being added without adding the current time to the expiration offset, resulting in the creation of already expired sessions